### PR TITLE
fix: make ec binary available to clamav image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY /start-clamd.sh /start-clamd.sh
 
 COPY --from=konflux-test /utils.sh /utils.sh
 
+COPY --from=konflux-test /usr/local/bin/ec /usr/local/bin/ec
 
 # Update ClamAV virus definitions
 RUN freshclam


### PR DESCRIPTION
Background:
* The clamav-scan for users is failing with the error "ec: command not found",
* The ec binary is not available to the image used by the clamav-scan. The image is: "quay.io/konflux-ci/clamav-db:latest"
* This image gets built from the Dockerfile github.com/konflux-ci/konflux-clamav/blob/main/Dockerfile
* You'd notice that it is a multi-stage Dockerfile with first stage using the konflux-test image, which contains the "ec" binary.
* But this binary isn't available to the second stage of the Dockerfile by default, since its present in the first stage.

Fix:
* So, the fix is to make the "ec" binary available to the second stage by using the COPY instruction
* And this is exactly what this commit does.