### PR TITLE
fix(KFLUXSPRT-4857): add false positive malware to whitelist

### DIFF
--- a/whitelist.ign2
+++ b/whitelist.ign2
@@ -1,1 +1,2 @@
 Win.Virus.Expiro-10026576-0
+Win.Malware.LNKAgent-10043840-0


### PR DESCRIPTION
Adding this malware to the known false positives after approval from product security. This issue was caused by a mismatch between ClamAV versions and the item should be removed once this has been fixed.