### PR TITLE
fix: add script runner image to additional base images

### DIFF
--- a/.tekton/clamav-hermetic-pull-request.yaml
+++ b/.tekton/clamav-hermetic-pull-request.yaml
@@ -245,6 +245,9 @@ spec:
         value: $(tasks.init.results.http-proxy)
       - name: NO_PROXY
         value: $(tasks.init.results.no-proxy)
+      - name: ADDITIONAL_BASE_IMAGES
+        value:
+          - $(tasks.fetch-db-data.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/clamav-hermetic-push.yaml
+++ b/.tekton/clamav-hermetic-push.yaml
@@ -236,6 +236,9 @@ spec:
         value: $(tasks.init.results.http-proxy)
       - name: NO_PROXY
         value: $(tasks.init.results.no-proxy)
+      - name: ADDITIONAL_BASE_IMAGES
+        value:
+          - $(tasks.fetch-db-data.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
* This adds the script runner image reference to the SBOM which resolves the Conforma violation `pre_build_script_task_runner_image_in_sbom`