### PR TITLE
fix(): enable multiarch support for the oc binary in the clamav image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,10 @@ RUN chown -R clamav:clamav /var/lib/clamav
 COPY /whitelist.ign2 /var/lib/clamav/whitelist.ign2
 COPY --from=konflux-test project $POLICY_PATH
 
-COPY openshift-client-linux.tar.gz /tmp/oc.tar.gz
-
+# TARGETARCH is set automatically by Buildah to the target platform arch
+# (amd64, arm64, ppc64le, s390x) matching the filenames fetched by fetch-db-and-tools.sh.
+ARG TARGETARCH=amd64
+COPY openshift-client-linux-${TARGETARCH}.tar.gz /tmp/oc.tar.gz
 RUN tar -xzvf /tmp/oc.tar.gz -C /usr/bin oc && \
     rm /tmp/oc.tar.gz && \
     chmod +x /usr/bin/oc

--- a/fetch-db-and-tools.sh
+++ b/fetch-db-and-tools.sh
@@ -23,20 +23,17 @@ freshclam --config-file=/tmp/freshclam.conf
 # Download GPG Key
 curl -L -o /var/workdir/source/RPM-GPG-KEY-EPEL-9 https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
 
-# Download OpenShift Client (architecture-aware)
-# Maps uname -m output to OpenShift mirror paths
-ARCH=$(uname -m)
-case "$ARCH" in
-    aarch64) OC_ARCH="aarch64" ;;
-    arm64)   OC_ARCH="arm64" ;;
-    x86_64)  OC_ARCH="x86_64" ;;
-    amd64)   OC_ARCH="amd64" ;;
-    ppc64le) OC_ARCH="ppc64le" ;;
-    s390x)   OC_ARCH="s390x" ;;
-    *)
-        echo "ERROR: Unsupported architecture: $ARCH" >&2
-        exit 1
-        ;;
-esac
-curl -L -o /var/workdir/source/openshift-client-linux.tar.gz \
-    "https://mirror.openshift.com/pub/openshift-v4/${OC_ARCH}/clients/ocp/stable/openshift-client-linux.tar.gz"
+# Download OpenShift Client for all supported build architectures.
+# Filenames use Docker TARGETARCH conventions so the Dockerfile can select
+# the correct tarball via ARG TARGETARCH at build time.
+declare -A OC_ARCH_MAP=(
+    [amd64]="x86_64"
+    [arm64]="aarch64"
+    [ppc64le]="ppc64le"
+    [s390x]="s390x"
+)
+for DOCKER_ARCH in "${!OC_ARCH_MAP[@]}"; do
+    OC_ARCH="${OC_ARCH_MAP[$DOCKER_ARCH]}"
+    curl -L -o "/var/workdir/source/openshift-client-linux-${DOCKER_ARCH}.tar.gz" \
+        "https://mirror.openshift.com/pub/openshift-v4/${OC_ARCH}/clients/ocp/stable/openshift-client-linux.tar.gz"
+done


### PR DESCRIPTION
The `fetch-db-data` pipeline task runs once on the pipeline runner (x86_64), so the previous `uname -m` based arch detection always downloaded the x86_64 oc binary. This binary was then embedded into all platform builds, including `arm64`, resulting in a non-native binary in the `arm64` image.

Fix by downloading the oc client for all supported architectures in `fetch-db-and-tools.sh`, naming each tarball with its Docker `TARGETARCH` convention (amd64, arm64, ppc64le, s390x).
The Dockerfile uses ARG TARGETARCH,
which Buildah sets automatically per platform during a multi-platform build, to COPY only the matching tarball at build time.

Assisted-By: Cursor