### PR TITLE
docs(STONEINTG-1613): add AGENTS.md and CONTRIBUTING.md guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+## Overview
+
+This repository contains a containerized [ClamAV](https://docs.clamav.net/) antivirus scanner designed for use in Konflux CI/CD pipelines. It builds a Docker image that includes ClamAV daemon (`clamd`) with optimized configuration for scanning container images and artifacts in CI/CD environments.
+
+## Technology Stack
+
+- **Language**: bash, Dockerfile
+- **Pipeline engine**: Tekton PipelineRuns
+- **Testing**: Tekton pipelines, GitHub actions
+- **Build**: Dockerfile, Tekton build pipelines
+
+## Repository Structure
+
+```
+integration-tests/     # Tekton pipeline and task definitions for running integration and e2e tests
+test/                  # Testing scripts that are used in the CI/CD pipelines
+rpms.*                 # Contain packages that are built hermetically with their corresponding location
+Dockerfile             # Container image definition
+```
+
+## Architecture
+
+### ClamAV Antivirus Engine
+
+The image is meant to be used as part of the [clamav-scan](https://github.com/konflux-ci/konflux-test-tasks/tree/main/task/clamav-scan) Konflux CI Tekton task.
+It is meant to provide the latest available version of the ClamAV utility with updated virus definitions database contained within it.
+The image's `Dockerfile` contains pre-tuned `clamd` settings for CI/CD scanning workflows - see more details in `README.md`.
+
+### Automated updates
+
+Automated virus definition updates are done via `freshclam` utility as part of the Konflux build pipeline defined in `.tekton/` directory.
+A new build of the image is triggered daily.
+
+## Development Guidelines
+
+- See `CONTRIBUTING.md` for overall guidelines for making contributions to this repository.
+- **Git**: conventional commits with Jira ticket as scope — `type(issue-id): description` (e.g. `feat(STONEINTG-1519): create PR group snapshots from ComponentGroups`)
+    - The `main` branch is read only, never push there directly, a new feature branch must be created instead
+    - Pull requests are used to propose changes to the `main` branch
+- Don't change whitespaces or newlines in the existing unrelated code and never add whitespaces or tabs to empty lines
+- Don't remove unrelated code and don't change files when/where modifications are not needed
+- Don't add trailing newlines at the end of file, last newline character is at the end of code
+- Never make changes that includes sensitive information like API keys, secrets, passwords, etc.
+- Comment changes, but only for logic that is not obvious.
+- Make sure that the Dockerfile is well-formatted and does not include unnecessary layers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing
+
+- [How to Report Issues](#how-to-report-issues)
+- [How to Submit Pull Requests](#how-to-submit-pull-requests)
+    - [Development Workflow](#development-workflow)
+    - [Pull Request Guidelines](#pull-request-guidelines)
+    - [Security basics](#security-basics)
+- [Review Process](#review-process)
+
+
+Contributions of all kinds are welcome. In particular pull requests are appreciated. The authors and maintainers will endeavor to help walk you through any issues in the pull request discussion, so please feel free to open a pull request even if you are new to such things.
+
+> [!NOTE]
+> This repository is used in [Konflux](https://konflux-ci.dev).
+> Therefore, everybody should follow its [Code of Conduct](https://github.com/konflux-ci/community/blob/main/CODE_OF_CONDUCT.md).
+
+## How to Report Issues
+
+- We encourage early communication for all types of contributions.
+- Before filing an issue, make sure to check if it is not reported already.
+- If the contribution is non-trivial (straightforward bugfixes, typos, etc.), please open an issue to discuss your plans and get guidance from maintainers.
+
+## How to Submit Pull Requests
+
+### Development Workflow
+
+1. **Fork and Clone**: Fork this repository and clone your fork
+2. **Create Feature Branch**: Create a new topic branch based on `main`
+3. **Make Changes**: Implement your changes. Consult [README.md](README.md) for the structure and development details.
+4. **Commit Changes**: See [commit guidelines](#pull-request-guidelines)
+
+### Pull Request Guidelines
+
+**Commit Requirements:**
+
+- Follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages
+- Write clear, descriptive commit titles. Should fit under 72 characters
+- Write meaningful commit descriptions with each line having less than 72 characters
+- Split your contribution into several commits if applicable, each should represent a logical chunk
+- Add line `Assisted-by: <name-of-ai-tool>` if you used an AI tool for your contribution
+- Sign-off your commits in order to certify that you adhere to [Developer Certificate of Origin](https://developercertificate.org)
+
+**Pull Request Content:**
+
+- **Title**: Clear, descriptive title. Should fit under 72 characters.
+- **Description**: Explain the overall changes and their purpose, this should be a cover letter for your commits.
+- **Testing**: Describe how the changes were tested
+- **Links**: Reference related issues or upstream stories.
+
+**Remember:**
+
+- Konflux is a community project and proper descriptions cannot be replaced by referencing a publicly inaccessible link to Jira or any other private resource.
+- Reviewers, other contributors and future generations might not have the same context as you have at the moment of PR submission.
+
+### Security basics
+
+- Never commit secrets or keys to the repository
+- Never expose or log sensitive information
+
+## Review Process
+
+**Requirements for Approval:**
+
+- All CI checks pass
+- Code review approval from maintainers
+
+**Review Criteria:**
+
+- The contribution follows established patterns and conventions
+- Changes are tested and documented
+- Security best practices are followed
+
+For any questions or help with contributing, please open an issue or reach out to the maintainers.


### PR DESCRIPTION
* Add the AGENTS.md with the basic context information for the repository including project structure, architecture and development guides
* Add the CONTRIBUTING.md with the standardized guidance for contributors to Konflux controller repositories