### PR TITLE
feat(STONEINTG-1643): add skills to clamav

### DIFF
--- a/.claude/skills/ci-pipeline-debugging
+++ b/.claude/skills/ci-pipeline-debugging
@@ -1,0 +1,1 @@
+../../skills/ci-pipeline-debugging

--- a/.claude/skills/daily-db-update
+++ b/.claude/skills/daily-db-update
@@ -1,0 +1,1 @@
+../../skills/daily-db-update

--- a/.claude/skills/hermetic-build-deps
+++ b/.claude/skills/hermetic-build-deps
@@ -1,0 +1,1 @@
+../../skills/hermetic-build-deps

--- a/.claude/skills/pr-definition-of-done
+++ b/.claude/skills/pr-definition-of-done
@@ -1,0 +1,1 @@
+../../skills/pr-definition-of-done

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -1,0 +1,41 @@
+# Konflux ClamAV AI Skills
+
+Skills for the **konflux-clamav** repository: a hermetic Konflux image that packages ClamAV virus definitions, `clamd`, and supporting tools for the platform `clamav-scan` task.
+
+Tool-agnostic content lives under `skills/`. Symlink into your agent (see below).
+
+## Skills
+
+| Skill | Use when |
+|-------|----------|
+| [ci-pipeline-debugging](ci-pipeline-debugging/SKILL.md) | Tekton build or scan failures, task order, integration self-test |
+| [hermetic-build-deps](hermetic-build-deps/SKILL.md) | RPMs, lockfiles, prefetch script, multi-arch `oc`, `clamav-db/` |
+| [pr-definition-of-done](pr-definition-of-done/SKILL.md) | Opening or reviewing a PR, CI check failures |
+| [daily-db-update](daily-db-update/SKILL.md) | Stale signatures, freshclam failures, push pipeline scheduling |
+
+## Claude Code
+
+```
+.claude/skills/ci-pipeline-debugging -> ../../skills/ci-pipeline-debugging
+.claude/skills/hermetic-build-deps -> ../../skills/hermetic-build-deps
+.claude/skills/pr-definition-of-done -> ../../skills/pr-definition-of-done
+.claude/skills/daily-db-update -> ../../skills/daily-db-update
+```
+
+## Cursor
+
+```bash
+mkdir -p .cursor/skills
+for s in ci-pipeline-debugging hermetic-build-deps pr-definition-of-done daily-db-update; do
+  ln -s "../../skills/$s" ".cursor/skills/$s"
+done
+```
+
+## Other agents
+
+```bash
+mkdir -p .agents/skills
+for s in ci-pipeline-debugging hermetic-build-deps pr-definition-of-done daily-db-update; do
+  ln -s "../../skills/$s" ".agents/skills/$s"
+done
+```

--- a/skills/ci-pipeline-debugging/SKILL.md
+++ b/skills/ci-pipeline-debugging/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: ci-pipeline-debugging
+description: Use when a Konflux Tekton build fails for konflux-clamav, when tracing task order or OCI artifacts, or when post-build security scans or the clamav-self-test integration pipeline fail.
+---
+
+# CI Pipeline Debugging
+
+## Overview
+
+The component `clamav-db-hermetic` is built from two PipelineRuns in `.tekton/`. Both produce a multi-arch image (`linux/x86_64`, `linux/arm64`) with embedded virus definitions and a preconfigured `clamd`.
+
+Only `fetch-db-data` runs with network access. It executes `fetch-db-and-tools.sh` (freshclam, EPEL GPG key, OpenShift client tarballs). Later tasks use Hermeto RPM/generic prefetch (`prefetch-dependencies`) and a hermetic `build-images` step.
+
+## When to Use
+
+- A Tekton task failed and you need its place in the pipeline
+- `fetch-db-data`, `prefetch-dependencies`, or `build-images` failed
+- A security scan after `build-image-index` failed
+- Integration pipeline `konflux-clamav-self-test` failed after a successful build
+
+## Task order
+
+```
+init
+  └─ clone-repository
+       └─ fetch-db-data          (HERMETIC=false)
+            └─ prefetch-dependencies
+                 └─ build-images          (matrix: x86_64, arm64)
+                      └─ build-image-index
+                           ├─ clair-scan, clamav-scan (per platform)
+                           ├─ sast-snyk-check, sast-shell-check, sast-unicode-check
+                           ├─ coverity-availability-check → sast-coverity-check
+                           ├─ ecosystem-cert-preflight-checks
+                           ├─ deprecated-base-image-check
+                           ├─ rpms-signature-scan
+                           ├─ apply-tags, push-dockerfile
+                           └─ build-source-image (only if param build-source-image=true)
+```
+
+**OCI trusted artifacts:** `SOURCE_ARTIFACT` flows clone → fetch-db-data → prefetch → build. `CACHI2_ARTIFACT` flows prefetch → build.
+
+## PR vs push
+
+| | Pull request | Push to `main` |
+|---|--------------|----------------|
+| File | `.tekton/clamav-hermetic-pull-request.yaml` | `.tekton/clamav-hermetic-push.yaml` |
+| Image tag | `clamav-db-hermetic:on-pr-{{revision}}` | `clamav-db-hermetic:{{revision}}` |
+| Expires | 5 days | Not set on push |
+| Cancel in-progress | yes | no |
+
+Registry: `quay.io/redhat-user-workloads/rhtap-integration-tenant/clamav-db-hermetic`  
+Service account: `build-pipeline-clamav-db-hermetic`
+
+## fetch-db-data
+
+Most prefetch failures show up here.
+
+| | |
+|---|---|
+| Task | `run-script-oci-ta` |
+| Script | `/var/workdir/source/fetch-db-and-tools.sh` |
+| Runner | `registry.access.redhat.com/ubi9/ubi:latest` |
+| `HERMETIC` | `"false"` |
+| Adds to source tree | `clamav-db/`, `RPM-GPG-KEY-EPEL-9`, `openshift-client-linux-{amd64,arm64,ppc64le,s390x}.tar.gz` |
+
+The script installs EPEL and `clamav-update` only to run `freshclam`; the final image installs ClamAV again during the hermetic build (see `hermetic-build-deps`).
+
+Virus DB size is on the order of a few hundred MB (`main.cvd`, `daily.cvd`, `bytecode.cvd`). Default task resources are usually enough unless logs show OOM.
+
+## build-image-index
+
+**`build-image-index`** combines per-platform **`build-images`** results into the published multi-arch image. Downstream tasks (scans, tags, chains) use its `IMAGE_URL` and `IMAGE_DIGEST`.
+
+Each **`build-images`** run uses `buildah-remote-oci-ta` (one per platform):
+
+| | |
+|---|---|
+| Task | `buildah-remote-oci-ta` (one run per platform) |
+| `HERMETIC` | `"true"` |
+| `ADDITIONAL_BASE_IMAGES` | Must include `$(tasks.fetch-db-data.results.SCRIPT_RUNNER_IMAGE_REFERENCE)` for SBOM/Conforma |
+
+The Dockerfile selects the OpenShift client with `ARG TARGETARCH` and `COPY openshift-client-linux-${TARGETARCH}.tar.gz`. The fetch script must place every tarball the Dockerfile can reference, even though only amd64 and arm64 are built today.
+
+## Security scans
+
+Runs when `skip-checks` is not `"true"`, after `build-image-index`. Standard Konflux catalog tasks: Clair, ClamAV, Snyk SAST, shell/unicode checks, optional Coverity, RPM signature scan, ecosystem preflight, deprecated base image check.
+
+This repository **ships** the ClamAV scanner image; the `clamav-scan` task in the pipeline still scans the **artifact you just built**, like any other component.
+
+## Integration test
+
+`integration-tests/clamav-self-test.yaml` runs `/selftest.sh` in the built image:
+
+- Verifies `clamdscan`, `clamscan`, and `freshclam` are present
+- Checks clamscan output format with a tiny local signature file (not a full DB regression)
+
+## Important notes
+
+- **`fetch-db-data` runs on the pipeline runner**, often amd64, but must still download oc tarballs for arm64 (and the other arches listed in `fetch-db-and-tools.sh`). Do not key downloads off `uname -m` alone.
+- **Tekton task bundles** in `.tekton/` use pinned `@sha256:` digests. Update them through MintMaker `chore(deps): update konflux references` PRs rather than editing SHAs by hand.
+- **Fork and dependency-bot PRs** may need a comment `/ok-to-test` before the full Konflux pipeline runs.
+- **PR builds** set `build-source-image` to `false` by default — do not expect a source image on every PR.
+- **PR image tags expire in five days** — not suitable for production virus-definition consumption.
+
+## Common failures
+
+| Failure | What to check |
+|---------|----------------|
+| freshclam error | Task log, ClamAV mirror reachability, retry pipeline |
+| curl / oc download | All four `openshift-client-linux-*.tar.gz` files in the source artifact |
+| prefetch-dependencies | `rpms.lock.yaml` in sync with `rpms.in.yaml` (regen via `rpm-lockfile-prototype`) |
+| build-images / wrong `oc` on arm64 | `OC_ARCH_MAP` in `fetch-db-and-tools.sh` and Dockerfile `TARGETARCH` |
+| Conforma / SBOM | `ADDITIONAL_BASE_IMAGES` includes script runner reference |
+| clamav-scan on built image | Scan logs; image content or policy, not “wrong repo” |
+| rpms-signature-scan | RPM sources and signatures in `rpms.lock.yaml` |
+| integration self-test | `/selftest.sh` output; confirm `clamav-db/` was copied into the image |

--- a/skills/daily-db-update/SKILL.md
+++ b/skills/daily-db-update/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: daily-db-update
+description: Use when ClamAV signatures in the published image are stale, when fetch-db-data or freshclam fails on push builds, or when verifying that main-branch builds still run on schedule.
+---
+
+# Daily Virus Definition Update
+
+## Overview
+
+This repository builds an image that embeds current ClamAV signature databases for use in Konflux malware scanning. Signatures are not vendored in git: each build runs `freshclam` in `fetch-db-and-tools.sh`, writes `clamav-db/`, and the Dockerfile copies that tree to `/var/lib/clamav/`.
+
+Production freshness depends on **push builds to `main`**, not short-lived PR tags.
+
+## When to Use
+
+- Scans report outdated signatures
+- `fetch-db-data` failed on a push pipeline
+- Confirming whether scheduled builds still run
+- Manually forcing a new image with current definitions
+
+## Scheduled refresh
+
+README and AGENTS.md describe a daily rebuild. There is **no** GitHub Actions workflow in this repo that commits to `main` on a cron. Scheduling is configured in Konflux/App Studio for application `konflux-clamav`, component `clamav-db-hermetic`.
+
+To verify scheduling:
+
+1. Konflux UI — recent `clamav-db-hermetic-on-push` PipelineRuns on `main`
+2. Quay — new digests on `quay.io/redhat-user-workloads/rhtap-integration-tenant/clamav-db-hermetic`
+3. Git history on `main` — commits that triggered pushes (may include automation outside this repo)
+
+## Push pipeline flow
+
+```
+push to main
+  └─ .tekton/clamav-hermetic-push.yaml
+       ├─ fetch-db-data (network on)
+       │    └─ fetch-db-and-tools.sh
+       │         ├─ freshclam → clamav-db/
+       │         ├─ RPM-GPG-KEY-EPEL-9
+       │         └─ openshift-client-linux-*.tar.gz
+       ├─ prefetch-dependencies
+       ├─ build-images (x86_64, arm64)
+       ├─ build-image-index
+       ├─ security scans
+       └─ apply-tags, push-dockerfile
+            └─ image tag: clamav-db-hermetic:{{revision}}
+```
+
+Integration test `clamav-self-test.yaml` runs afterward; it checks binaries and clamscan output shape, not that signatures match a particular date.
+
+## fetch-db-data
+
+| | |
+|---|---|
+| Task | `run-script-oci-ta` |
+| Script | `fetch-db-and-tools.sh` |
+| Runner | `ubi9/ubi:latest` |
+| Network | Required (`HERMETIC=false`) |
+| Mirror | `database.clamav.net` (written into `/tmp/freshclam.conf` at runtime) |
+
+Approximate download sizes: `main.cvd` ~170 MB, `daily.cvd` ~65 MB, `bytecode.cvd` under 1 MB.
+
+## Push vs pull request images
+
+| | Push (`main`) | Pull request |
+|---|---------------|--------------|
+| Tag | `{{revision}}` | `on-pr-{{revision}}` |
+| Expiry | None in pipeline | 5 days |
+| Use for fresh DB | Yes | No — PR tags are for validation only |
+
+## Manual rebuild
+
+1. Start a component build for `clamav-db-hermetic` on `main` in Konflux/App Studio, or
+2. Push to `main` (subject to branch protection), then
+3. Confirm a successful push PipelineRun and a new tag on Quay.
+
+Tenants reference this image by digest or tag in their own Konflux configuration. Publishing a new image here does not update every consumer until they point at the new digest.
+
+## After a successful push
+
+1. `fetch-db-data` logs show freshclam completing without error
+2. Security scan tasks finished (unless intentionally skipped)
+3. Integration `clamav-self-test` passed
+4. Optional: run the image and list `/var/lib/clamav/*.cvd` 
+
+## Important notes
+
+- Green PR builds do not refresh production — PR tags expire and are not the delivery path for daily definitions.
+- Intermittent freshclam failures are usually mirror or network issues; retry the pipeline.
+- New signatures can surface detections that are false positives for your workloads — add entries to `whitelist.ign2` only with maintainer agreement and a tracked justification.
+- `selftest.sh` passing does not prove signatures are current; it only proves tooling works.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| Stale signatures in CI | No recent push build | Run push pipeline on `main` |
+| freshclam failure | CDN or network | Task logs; retry |
+| curl failures in fetch | oc or GPG download | Check `fetch-db-and-tools.sh` and mirror status |
+| Downstream still stale | Old image digest pinned | Update consumer component image reference |
+| Integration test failed | Broken image build | Inspect `/selftest.sh` in task logs |
+| New false positive | DB update | Review `whitelist.ign2` with evidence |

--- a/skills/hermetic-build-deps/SKILL.md
+++ b/skills/hermetic-build-deps/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: hermetic-build-deps
+description: Use when changing RPMs, lockfiles, prefetch artifacts, or multi-arch inputs for the konflux-clamav hermetic image build. Covers rpms.in.yaml, rpm-lockfile-prototype, Hermeto prefetch, fetch-db-and-tools.sh, and Dockerfile COPY paths.
+---
+
+# Hermetic Build Dependencies
+
+## Overview
+
+`build-images` runs with `HERMETIC: "true"` — no network during the image build. Everything the Dockerfile needs must already be in the source artifact chain or in Hermeto output from `prefetch-dependencies`.
+
+Two independent prefetch paths feed the build:
+
+1. **`fetch-db-data`** — `fetch-db-and-tools.sh` (network allowed)
+2. **RPM prefetch (Hermeto)** — packages listed in `rpms.in.yaml`, resolved in `rpms.lock.yaml`, fetched by `prefetch-dependencies`
+3. **Generic prefetch** — artifacts.lock.yaml has artifacts: []; generic prefetch is still enabled in prefetch-input, but virus DB, GPG key, and oc tarballs come from fetch-db-data, not this file.
+
+## When to Use
+
+- Adding or updating packages in the image
+- `prefetch-dependencies` checksum or resolution errors
+- Missing or wrong-arch `oc` in the built image
+- Missing `clamav-db/` in the image
+- Deciding what belongs in lockfiles vs the fetch script
+
+## Files
+
+| File | Role |
+|------|------|
+| `rpms.in.yaml` | Package list, `ubi.repo` / `epel.repo`, arches `x86_64` and `aarch64` |
+| `rpms.lock.yaml` | Generated from `rpms.in.yaml` (`lockfileVendor: redhat`); refresh via MintMaker or `rpm-lockfile-prototype` |
+| `artifacts.lock.yaml` | Generic Hermeto artifacts (`artifacts: []` no pinned entries) |
+| `ubi.repo`, `epel.repo` | Repo definitions referenced by `contentOrigin.repofiles` |
+| `fetch-db-and-tools.sh` | Builds `clamav-db/`, GPG key, oc tarballs (not committed) |
+
+Pipeline parameter:
+
+```yaml
+prefetch-input: '[{"type": "rpm", "path": "."}, {"type": "generic", "path": "."}]'
+```
+
+## Data flow
+
+```
+fetch-db-data
+  clamav-db/                              (freshclam)
+  RPM-GPG-KEY-EPEL-9
+  openshift-client-linux-<arch>.tar.gz    (four arches)
+
+prefetch-dependencies (Hermeto)
+  rpm     ← rpms.in.yaml + rpms.lock.yaml
+  generic ← artifacts.lock.yaml
+
+build-images (hermetic Dockerfile)
+  COPY clamav-db, GPG key, oc tarball for TARGETARCH
+  microdnf install clamav, clamd, jq, skopeo, tar, …  (from prefetched RPM set)
+  COPY --from=konflux-test utils.sh, ec, policy tree
+```
+
+## Dockerfile expectations
+
+| Input | Origin |
+|-------|--------|
+| `clamav-db/` → `/var/lib/clamav/` | `fetch-db-and-tools.sh` |
+| `RPM-GPG-KEY-EPEL-9` | `fetch-db-and-tools.sh` |
+| `openshift-client-linux-${TARGETARCH}.tar.gz` | `fetch-db-and-tools.sh` |
+| `whitelist.ign2` | Git |
+| `start-clamd.sh`, `test/selftest.sh` | Git |
+| ClamAV RPMs in `RUN microdnf install` | Must match `rpms.in.yaml` |
+
+If you add a package to `rpms.in.yaml`, refresh `rpms.lock.yaml` and add it to the Dockerfile install list when it is part of the runtime image.
+
+## OpenShift client (multi-arch)
+
+`fetch-db-and-tools.sh` downloads one tarball per Docker architecture name:
+
+```bash
+declare -A OC_ARCH_MAP=(
+    [amd64]="x86_64"
+    [arm64]="aarch64"
+    [ppc64le]="ppc64le"
+    [s390x]="s390x"
+)
+```
+
+The build matrix today is amd64 and arm64 only, but all four tarballs must exist so `COPY openshift-client-linux-${TARGETARCH}.tar.gz` never points at a missing file.
+
+The fetch task typically runs on an x86_64 runner. arm64 images still require the arm64 tarball in the shared source artifact.
+
+## Virus database
+
+- Not stored in git; created under `clamav-db/` during `fetch-db-data`
+- Typical files: `main.cvd`, `daily.cvd`, `bytecode.cvd`
+- Installed in the image at `/var/lib/clamav/`
+- False-positive signatures: `whitelist.ign2` in git
+
+## RPM lock files (rpms.in.yaml → rpms.lock.yaml)
+
+You maintain `rpms.in.yaml`; **do not** hand-edit `rpms.lock.yaml`. Regenerate the lock with **`rpm-lockfile-prototype`** (Konflux/Hermeto standard). The pipeline’s `prefetch-dependencies` task then uses Hermeto to download the pinned RPMs for offline install.
+
+**This repository:**
+
+- `packages:` lists top-level RPMs only (transitives are resolved by the tool)
+- `contentOrigin.repofiles`: `./ubi.repo`, `./epel.repo`
+- `arches:` `x86_64`, `aarch64` — required for the multi-arch build matrix
+- Lock output: `lockfileVersion: 1`, `lockfileVendor: redhat`
+
+**Regenerate locally** (use the same UBI image as the final `FROM` line in `Dockerfile`):
+
+```bash
+rpm-lockfile-prototype --image registry.access.redhat.com/ubi9/ubi:<tag> rpms.in.yaml
+```
+
+Commit the updated `rpms.lock.yaml`. In practice, MintMaker often opens `chore(deps): refresh rpm lockfiles` PRs after `rpms.in.yaml` changes — merging those is fine.
+
+Docs: [Konflux — prefetching RPM dependencies](https://konflux.pages.redhat.com/docs/users/building/prefetching-dependencies.html#enabling-prefetch-builds-for-rpm)
+
+## Adding an RPM
+
+1. Add the package name to `packages:` in `rpms.in.yaml` (not every transitive dep)
+2. Regenerate `rpms.lock.yaml` with `rpm-lockfile-prototype` (see above) or merge a MintMaker lockfile PR
+3. Add the package to the Dockerfile `microdnf install` line if it belongs in the final image
+4. Open a PR and run the Konflux pipeline — local `docker build` alone does not run `fetch-db-data` or Hermeto prefetch
+
+## Important notes
+
+- **Do not use `cachi2 fetch-deps` to refresh `rpms.lock.yaml`** — that is not the Konflux workflow for RPM locks; use `rpm-lockfile-prototype`.
+- **Two ClamAV installs:** the fetch script installs `clamav` and `clamav-update` temporarily to run `freshclam`; the image installs the production set via hermetic RPM prefetch. Version skew between them can cause confusing failures.
+- **Multi-arch:** both `x86_64` and `aarch64` must appear in `rpms.in.yaml` `arches` or the prefetch/build matrix fails.
+- **Empty `artifacts.lock.yaml`:** generic prefetch is enabled but most non-RPM inputs come from the fetch script, not the lock file.
+- **EPEL during fetch only:** `rpm -ivh epel-release` in `fetch-db-and-tools.sh` uses the network in `fetch-db-data`; the image imports `RPM-GPG-KEY-EPEL-9` from the build context.
+- **Lock file edits:** prefer MintMaker or `rpm-lockfile-prototype` over hand-editing `rpms.lock.yaml`.
+
+## Common failures
+
+| Problem | Fix |
+|---------|-----|
+| Checksum mismatch in prefetch | Regenerate `rpms.lock.yaml` with `rpm-lockfile-prototype` |
+| Package not found | Fix name or repos in `rpms.in.yaml` / `ubi.repo` / `epel.repo` |
+| No virus DB in image | Fix `fetch-db-data` / `COPY clamav-db` |
+| Broken `oc` on arm64 | Ensure `openshift-client-linux-arm64.tar.gz` is in the source artifact |
+| Network error during hermetic build | Missing prefetch input — nothing may be downloaded at build time |

--- a/skills/pr-definition-of-done/SKILL.md
+++ b/skills/pr-definition-of-done/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: pr-definition-of-done
+description: Use before opening or updating a konflux-clamav pull request, or when GitHub Actions or Konflux pipeline checks fail. Covers commits, formatting, lockfiles, and expected CI outcomes.
+---
+
+# PR Definition of Done
+
+## Overview
+
+A pull request to `main` runs GitHub Actions and a Konflux hermetic build for component `clamav-db-hermetic`. Merging triggers the push pipeline, which publishes a durable image tag with refreshed virus definitions.
+
+## When to Use
+
+- Before pushing or marking a PR ready for review
+- Mapping a failed check to a required fix
+- Reviewing someone else's change
+
+## Pre-push checklist
+
+### Commits
+
+- [ ] `type(JIRA-ID): description` (e.g. `fix(STONEINTG-1288): extend whitelist for foo`)
+- [ ] Type is one of: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`
+- [ ] `git commit -s` (DCO sign-off)
+- [ ] Title and body lines under 72 characters
+- [ ] `Assisted-by: <tool>` if an AI tool helped
+- [ ] Branch from `main`; merge via PR (do not push directly to `main`)
+
+### Edits in this repository
+
+- [ ] No drive-by whitespace or unrelated file changes
+- [ ] No spaces or tabs on empty lines
+- [ ] Exactly one newline at EOF (no extra blank lines after the last line)
+- [ ] No secrets, keys, or credentials
+
+### Image and build inputs
+
+- [ ] Dockerfile changes stay minimal; touch the `clamd` `sed` block only when scan behavior requires it
+- [ ] RPM changes: `rpms.in.yaml`, `rpms.lock.yaml`, and Dockerfile `microdnf` list updated together
+- [ ] Prefetch changes: `fetch-db-and-tools.sh` outputs still match Dockerfile `COPY` paths
+- [ ] Multi-arch: oc tarball names and `TARGETARCH` stay aligned
+
+### Dependencies and Tekton
+
+- [ ] After editing `rpms.in.yaml`, `rpms.lock.yaml` is regenerated (`rpm-lockfile-prototype` or MintMaker lockfile PR)
+- [ ] Tekton bundle digest bumps via MintMaker `chore(deps): update konflux references`, not ad hoc SHA edits
+
+### Pull request text
+
+- [ ] Title under 72 characters, describes the change
+- [ ] Description explains why (understandable without private Jira-only context)
+- [ ] Testing section states what was run (Konflux pipeline, local attempts, etc.)
+- [ ] Related tickets or issues linked when they exist
+
+### Konflux on forks
+
+- [ ] Comment `/ok-to-test` if the Tekton pipeline did not start on a fork or bot PR
+
+## CI that runs on pull requests
+
+### GitHub Actions
+
+| Workflow | Path | Purpose |
+|----------|------|---------|
+| Agentready | `.github/workflows/agentready.yaml` | Repo readiness per `.agentready/config/.agentready-config.yaml` |
+
+There is no `make test`, unit test workflow, or Dockerfile hadolint job in this repository.
+
+### Konflux Tekton
+
+Defined in `.tekton/clamav-hermetic-pull-request.yaml`:
+
+| Stage | Work |
+|-------|------|
+| Prefetch | `fetch-db-data` → `prefetch-dependencies` |
+| Build | `build-images` (x86_64, arm64) → `build-image-index` |
+| Scans | Clair, ClamAV, SAST tasks, RPM signature, preflight, deprecated base |
+| Metadata | `apply-tags`, `push-dockerfile` |
+
+PR images are tagged `on-pr-{{revision}}` and expire after five days.
+
+### Integration test
+
+`integration-tests/clamav-self-test.yaml` exercises `/selftest.sh` inside the built image after the component build succeeds in Konflux integration testing.
+
+## Reviewers
+
+See `.github/CODEOWNERS` for automatic review requests.
+
+## Downstream impact
+
+Consumers use this image from the [clamav-scan](https://github.com/konflux-ci/konflux-test-tasks/tree/main/task/clamav-scan) Tekton task. Changes to entrypoint (`/start-clamd.sh`), socket path (`/var/run/clamd.scan/clamd.sock`), or database layout under `/var/lib/clamav/` can break existing pipelines.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| `rpms.in.yaml` without lock refresh | Regenerate with `rpm-lockfile-prototype` or merge MintMaker lockfile PR |
+| Only one oc tarball in fetch script | Download every arch in `fetch-db-and-tools.sh` |
+| SBOM/Conforma failure | `ADDITIONAL_BASE_IMAGES` includes `SCRIPT_RUNNER_IMAGE_REFERENCE` in `.tekton/` |
+| Unsigned commit | `git commit -s` |
+| Pipeline never started | `/ok-to-test` |
+| Local `docker build` assumed equal to CI | Reproduce `fetch-db-data` + Hermeto prefetch or rely on Konflux PR build |


### PR DESCRIPTION
Add four repository-specific AI skills for konflux-clamav:
- ci-pipeline-debugging
- hermetic-build-deps
- pr-definition-of-done
- daily-db-update

Assisted-by: Cursor