### PR TITLE
fix(STONEINTG-1699): disable internal email scanner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN sed -i 's|^#LogFile .*|LogFile /var/log/clamav/clamd.log|' /etc/clamd.d/scan
     sed -i 's|^#AlertPhishingSSLMismatch .*|AlertPhishingSSLMismatch yes|' /etc/clamd.d/scan.conf && \
     sed -i 's|^#AlertPhishingCloak .*|AlertPhishingCloak yes|' /etc/clamd.d/scan.conf && \
     sed -i 's|^#AlertPartitionIntersection .*|AlertPartitionIntersection yes|' /etc/clamd.d/scan.conf && \
+    sed -i 's|^#ScanMail .*|ScanMail no|' /etc/clamd.d/scan.conf && \
     sed -i 's|^#MaxScanTime .*|MaxScanTime 0|' /etc/clamd.d/scan.conf && \
     sed -i 's|^#MaxScanSize .*|MaxScanSize 4095M|' /etc/clamd.d/scan.conf && \
     sed -i 's|^#MaxFileSize .*|MaxFileSize 2000M|' /etc/clamd.d/scan.conf && \


### PR DESCRIPTION
Disabling this prevents clamav from misidentifying very large files as email files and trying to parse them as separate individual messages and attachments, which causes the scan to take 5-10 times longer.

The files will still be scanned.

ScanMail behavior is a bad fit for the purposes of scanning product artifacts: we're not scanning an inbox where it might make sense to flag an individual message as dangerous, we just need to know if files as a whole have dangerous bits.