### PR TITLE
fix(STONEINTG-1713): add clamupdate user to fetch script

### DIFF
--- a/fetch-db-and-tools.sh
+++ b/fetch-db-and-tools.sh
@@ -15,7 +15,7 @@ DB_DIR=/var/workdir/source/clamav-db
 mkdir -p "$DB_DIR"
 chmod 777 "$DB_DIR"
 
-# Add clamupdate user (idempotent)
+# Add clamupdate user (idempotent) - this user is needed for the Freshclam utility
 if ! getent group clamupdate >/dev/null; then
   groupadd -r clamupdate
 fi

--- a/fetch-db-and-tools.sh
+++ b/fetch-db-and-tools.sh
@@ -15,6 +15,14 @@ DB_DIR=/var/workdir/source/clamav-db
 mkdir -p "$DB_DIR"
 chmod 777 "$DB_DIR"
 
+# Add clamupdate user (idempotent)
+if ! getent group clamupdate >/dev/null; then
+  groupadd -r clamupdate
+fi
+if ! id -u clamupdate >/dev/null 2>&1; then
+  useradd -r -g clamupdate -M -s /sbin/nologin -c "Clam Antivirus Update" clamupdate
+fi
+
 # Run Freshclam 
 echo "DatabaseDirectory $DB_DIR" > /tmp/freshclam.conf
 echo "DatabaseMirror database.clamav.net" >> /tmp/freshclam.conf

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -137,41 +137,41 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-16.el9
     sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://mirrors.iu13.net/epel/9/Everything/aarch64/Packages/c/clamav-1.4.3-3.el9.aarch64.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/aarch64/Packages/c/clamav-1.4.5-1.el9.aarch64.rpm
     repoid: epel
-    size: 3789815
-    checksum: sha256:4ffefa33fa6b18c800f4c88c1b3fa49d23d73842db929b9df9de7d3f353d8c75
+    size: 3681355
+    checksum: sha256:4e773010c0b75d7555d391b852c0738ed23010a9245674ef5b53983dcaa8c238
     name: clamav
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
-  - url: https://mirrors.iu13.net/epel/9/Everything/aarch64/Packages/c/clamav-filesystem-1.4.3-3.el9.noarch.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/aarch64/Packages/c/clamav-filesystem-1.4.5-1.el9.noarch.rpm
     repoid: epel
-    size: 17833
-    checksum: sha256:18a441394a4ac51074ca8c90fc9f6112bc818578a4d9d08acdf19805d95dc352
+    size: 17876
+    checksum: sha256:d2d28c782ce6f457d2f9de6975d22951ff0cda842ee76930418574b4ca980d86
     name: clamav-filesystem
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
-  - url: https://mirrors.iu13.net/epel/9/Everything/aarch64/Packages/c/clamav-freshclam-1.4.3-3.el9.aarch64.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/aarch64/Packages/c/clamav-freshclam-1.4.5-1.el9.aarch64.rpm
     repoid: epel
-    size: 3025975
-    checksum: sha256:f52cacab90b80f3235ce2382d874718266304087e7c0f70fb45e610408b2151a
+    size: 2934688
+    checksum: sha256:6128b4033658e2b195d6bf4593d4bc0483b37e2a5c06cd8679ab6acc6b342a1b
     name: clamav-freshclam
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
-  - url: https://mirrors.iu13.net/epel/9/Everything/aarch64/Packages/c/clamav-lib-1.4.3-3.el9.aarch64.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/aarch64/Packages/c/clamav-lib-1.4.5-1.el9.aarch64.rpm
     repoid: epel
-    size: 3707396
-    checksum: sha256:d71b6fbca9979a972feb6541062146cde4e477d538684f61155a59d3430a7b99
+    size: 3617405
+    checksum: sha256:905e472e0ac0a21d0668d5f24ae2475241bdcf0ef19c705474ef3a91dab74460
     name: clamav-lib
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
-  - url: https://mirrors.iu13.net/epel/9/Everything/aarch64/Packages/c/clamd-1.4.3-3.el9.aarch64.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/aarch64/Packages/c/clamd-1.4.5-1.el9.aarch64.rpm
     repoid: epel
-    size: 94009
-    checksum: sha256:ddaf96d654136da65db57e8a247d763164bcbd54345225bfd168e98279cc9ef0
+    size: 94229
+    checksum: sha256:a25fd67e68dc8716dbd99c18bc8e687dbaf86b87a83552bab4a28ebc8b9d5107
     name: clamd
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64
@@ -309,40 +309,40 @@ arches:
     name: shadow-utils-subid
     evr: 2:4.9-16.el9
     sourcerpm: shadow-utils-4.9-16.el9.src.rpm
-  - url: https://nocix.mm.fcix.net/epel/9/Everything/x86_64/Packages/c/clamav-1.4.3-3.el9.x86_64.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/x86_64/Packages/c/clamav-1.4.5-1.el9.x86_64.rpm
     repoid: epel
-    size: 7038941
-    checksum: sha256:3976a48f6eb2a27e3e6d777b5b2c23782a47b825205438969c0a1534976b4ea3
+    size: 6944750
+    checksum: sha256:0c517faf0d9ce275ba124bc9aea81f8f90917114c54850c6d572d74fb47adf15
     name: clamav
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
-  - url: https://nocix.mm.fcix.net/epel/9/Everything/x86_64/Packages/c/clamav-filesystem-1.4.3-3.el9.noarch.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/x86_64/Packages/c/clamav-filesystem-1.4.5-1.el9.noarch.rpm
     repoid: epel
-    size: 17833
-    checksum: sha256:18a441394a4ac51074ca8c90fc9f6112bc818578a4d9d08acdf19805d95dc352
+    size: 17876
+    checksum: sha256:d2d28c782ce6f457d2f9de6975d22951ff0cda842ee76930418574b4ca980d86
     name: clamav-filesystem
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
-  - url: https://nocix.mm.fcix.net/epel/9/Everything/x86_64/Packages/c/clamav-freshclam-1.4.3-3.el9.x86_64.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/x86_64/Packages/c/clamav-freshclam-1.4.5-1.el9.x86_64.rpm
     repoid: epel
-    size: 3460373
-    checksum: sha256:f1916aba45bb3d39f20c90acd630f79214f4e4c0988e64cc3906053dd891cd0e
+    size: 3406454
+    checksum: sha256:d873157e1a89fef725e3575a9a4b0efe856014ae62d1de12d0f29e0047b56a9c
     name: clamav-freshclam
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
-  - url: https://nocix.mm.fcix.net/epel/9/Everything/x86_64/Packages/c/clamav-lib-1.4.3-3.el9.x86_64.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/x86_64/Packages/c/clamav-lib-1.4.5-1.el9.x86_64.rpm
     repoid: epel
-    size: 4159687
-    checksum: sha256:49be3f72c741257e98d9d4e463ee7fa2527672906aa31b21dcce89ce4bb3ed1d
+    size: 4100557
+    checksum: sha256:d16fc06393d5b8a72cf7073df803a9c9c65ed3bd3a57a72b7a6877d4ecbff399
     name: clamav-lib
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
-  - url: https://nocix.mm.fcix.net/epel/9/Everything/x86_64/Packages/c/clamd-1.4.3-3.el9.x86_64.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
+  - url: https://d2lzkl7pfhq30w.cloudfront.net/pub/epel/9/Everything/x86_64/Packages/c/clamd-1.4.5-1.el9.x86_64.rpm
     repoid: epel
-    size: 94679
-    checksum: sha256:1e3f0a94e2e0e613dbfc43333044ee063157fa6905a318a05843ce7a3399f2db
+    size: 94848
+    checksum: sha256:184c55605f797cec8e2a2fa7a05bf6c93fc1f0cd2798fa3250fa9b973aa94094
     name: clamd
-    evr: 1.4.3-3.el9
-    sourcerpm: clamav-1.4.3-3.el9.src.rpm
+    evr: 1.4.5-1.el9
+    sourcerpm: clamav-1.4.5-1.el9.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
This fix adds the clamupdate user which is newly required by the `freshclam` utility. 
It resolves the error which happens during fetch-db-and-tools script execution: 
```
ERROR: Can't get information about user clamupdate.
```
This PR also updates the rpms lock file (in a separate commit) in order to resolve the deadlock with #179  as the mirrors for previous rpm entries are not reachable anymore.

Signed-off-by: dirgim <kpavic@redhat.com>